### PR TITLE
Added WSL/Windows support for running this on WSL2 with (optionally) a windows

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -11,6 +11,8 @@ set -o errexit  # abort on nonzero exitstatus
 set -o nounset  # abort on unbound variable
 set -o pipefail # don't hide errors within pipes
 
+trap '[[ $? -ne 0 ]] && echo "Hit <Enter> to exit" && read' EXIT
+
 readonly yellow='\e[0;33m'
 readonly green='\e[0;32m'
 readonly red='\e[0;31m'


### PR DESCRIPTION
Closes #1 .

Added support for running this on bash on WSL2 using (optionally) a windows multipass executable. Added shell script traps to catch errors. Tested on:

```
[sector17g] --> uname -a
Linux sector17g 5.15.133.1-microsoft-standard-WSL2 #1 SMP Thu Oct 5 21:02:42 UTC 2023 x86_64 GNU/Linux
[sector17g] --> cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```
